### PR TITLE
Remove nixpkgs input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,26 +1,6 @@
 {
   "nodes": {
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1734737257,
-        "narHash": "sha256-GIMyMt1pkkoXdCq9un859bX6YQZ/iYtukb9R5luazLM=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1c6e20d41d6a9c1d737945962160e8571df55daa",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "root": {
-      "inputs": {
-        "nixpkgs": "nixpkgs"
-      }
-    }
+    "root": {}
   },
   "root": "root",
   "version": 7

--- a/flake.nix
+++ b/flake.nix
@@ -5,16 +5,13 @@
     [Documentation](https://garnix.io/docs/modules/user) - [Source](https://github.com/garnix-io/user-module).
   '';
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
-
   outputs =
     { self
-    , nixpkgs
     ,
     }:
+    {
+      garnixModules.default = { pkgs, lib, config, ... }:
     let
-      lib = nixpkgs.lib;
-
       userSubmodule.options = {
         user = lib.mkOption
           {
@@ -46,7 +43,6 @@
       };
     in
     {
-      garnixModules.default = { pkgs, config, ... }: {
         options = {
           user = lib.mkOption {
             type = lib.types.attrsOf (lib.types.submodule userSubmodule);
@@ -82,4 +78,3 @@
       };
     };
 }
-

--- a/flake.nix
+++ b/flake.nix
@@ -6,75 +6,87 @@
   '';
 
   outputs =
-    { self
-    ,
-    }:
+    { self }:
     {
-      garnixModules.default = { pkgs, lib, config, ... }:
-    let
-      userSubmodule.options = {
-        user = lib.mkOption
-          {
-            type = lib.types.nonEmptyStr;
-            description = "The Linux username.";
-            example = "alice";
-          } // { name = "user name"; };
+      garnixModules.default =
+        {
+          pkgs,
+          lib,
+          config,
+          ...
+        }:
+        let
+          userSubmodule.options = {
+            user =
+              lib.mkOption {
+                type = lib.types.nonEmptyStr;
+                description = "The Linux username.";
+                example = "alice";
+              }
+              // {
+                name = "user name";
+              };
 
-        groups = lib.mkOption {
-          type = lib.types.listOf lib.types.str;
-          description = "The groups the user belongs to.";
-          example = [ "wheel" ];
-          default = [ ];
-        };
+            groups = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              description = "The groups the user belongs to.";
+              example = [ "wheel" ];
+              default = [ ];
+            };
 
-        shell = lib.mkOption {
-          type = lib.types.enum [ "bash" "zsh" "fish" ];
-          default = "bash";
-          description = "The users login shell.";
-        };
+            shell = lib.mkOption {
+              type = lib.types.enum [
+                "bash"
+                "zsh"
+                "fish"
+              ];
+              default = "bash";
+              description = "The users login shell.";
+            };
 
-        authorizedSshKeys = lib.mkOption
-          {
-            type = lib.types.listOf lib.types.nonEmptyStr;
-            description =
-              ''The public SSH keys that can be used to log in as this user. (Note that you must
-            use the IP address rather than domain for SSH.)'';
-          } // { name = "SSH keys"; };
-      };
-    in
-    {
-        options = {
-          user = lib.mkOption {
-            type = lib.types.attrsOf (lib.types.submodule userSubmodule);
-            description = "An attrset of users.";
+            authorizedSshKeys =
+              lib.mkOption {
+                type = lib.types.listOf lib.types.nonEmptyStr;
+                description = ''
+                  The public SSH keys that can be used to log in as this user. (Note that you must
+                              use the IP address rather than domain for SSH.)'';
+              }
+              // {
+                name = "SSH keys";
+              };
+          };
+        in
+        {
+          options = {
+            user = lib.mkOption {
+              type = lib.types.attrsOf (lib.types.submodule userSubmodule);
+              description = "An attrset of users.";
+            };
+          };
+
+          config = {
+            nixosConfigurations.default = builtins.attrValues (
+              builtins.mapAttrs (name: projectConfig: {
+                users.users.${projectConfig.user} = {
+                  extraGroups = projectConfig.groups;
+                  isNormalUser = true;
+                  shell = pkgs.${projectConfig.shell};
+                  openssh.authorizedKeys.keys = projectConfig.authorizedSshKeys;
+                };
+                programs.zsh.enable = projectConfig.shell == "zsh";
+                programs.fish.enable = projectConfig.shell == "fish";
+                services.openssh = {
+                  enable = true;
+                  settings = {
+                    PasswordAuthentication = false;
+                    KbdInteractiveAuthentication = false;
+                    AuthenticationMethods = "publickey";
+                    PermitRootLogin = "prohibit-password";
+                  };
+                };
+              }) config.user
+            );
           };
         };
-
-        config =
-          {
-            nixosConfigurations.default =
-              builtins.attrValues (builtins.mapAttrs
-                (name: projectConfig: {
-                  users.users.${projectConfig.user} = {
-                    extraGroups = projectConfig.groups;
-                    isNormalUser = true;
-                    shell = pkgs.${projectConfig.shell};
-                    openssh.authorizedKeys.keys = projectConfig.authorizedSshKeys;
-                  };
-                  programs.zsh.enable = projectConfig.shell == "zsh";
-                  programs.fish.enable = projectConfig.shell == "fish";
-                  services.openssh = {
-                    enable = true;
-                    settings = {
-                      PasswordAuthentication = false;
-                      KbdInteractiveAuthentication = false;
-                      AuthenticationMethods = "publickey";
-                      PermitRootLogin = "prohibit-password";
-                    };
-                  };
-                })
-                config.user);
-          };
-      };
     };
 }


### PR DESCRIPTION
The `nixpkgs` dependency was only being used for library functions, and
these functions are only needed within `garnixModules.default` which
receives `lib` from `garnix-lib`. By removing the `nixpkgs` input we can
be assured that there is only one `nixpkgs` being used: the one passed
in from `garnix-lib`.